### PR TITLE
Update database.js

### DIFF
--- a/intellij-projects/selenium-tests/docker/react-weather-app/src/backend/database.js
+++ b/intellij-projects/selenium-tests/docker/react-weather-app/src/backend/database.js
@@ -9,6 +9,10 @@ const ENCRYPTION_KEY = 'your-encryption-key'; // Replace with your actual encryp
 const IV_LENGTH = 16;
 
 function encrypt(text) {
+  if (!text) {
+    throw new Error('Input text cannot be null or empty');
+  }
+  text = text.toString();
   let iv = crypto.randomBytes(IV_LENGTH);
   let cipher = crypto.createCipheriv('aes-256-cbc', crypto.scryptSync(ENCRYPTION_KEY, 'salt', 32), iv);
   let encrypted = cipher.update(text);


### PR DESCRIPTION
### **User description**
**Notes for Reviewers**

This PR fixes #




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added null or empty input validation in `encrypt` function.

- Ensured input text is converted to string before encryption.

- Minor formatting adjustment in `export default Database`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>database.js</strong><dd><code>Enhance `encrypt` function with input validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

intellij-projects/selenium-tests/docker/react-weather-app/src/backend/database.js

<li>Added validation for null or empty input in <code>encrypt</code>.<br> <li> Converted input text to string before encryption.<br> <li> Adjusted formatting for <code>export default Database</code>.


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/devlabs/pull/8/files#diff-383cdc7b361471b621e6264147d8a2c2afbeba6b8f4f422167ef3cae70b809e5">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>